### PR TITLE
Fix "New Order" form on mobile.

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
                 <li role="presentation"><a href="#sell" aria-controls="sell" role="tab" data-toggle="tab" class="trn">sell</a></li>
               </ul>
             </div>
-            <div class="row-box height3 padding">
+            <div class="row-box height6 padding">
               <input type="hidden" id="tokenAddr" value="<%= selectedToken.addr %>" />
               <input type="hidden" id="baseAddr" value="<%= selectedBase.addr %>" />
 


### PR DESCRIPTION
The `New Order` form is showing only partially on mobile. Changing its class to `.height6` rectifies the issue, while doesn't seem to break anything on a desktop browser.

***Note:** My screen resolution is 1280x800, so it would be wise to test it on higher resolutions, to make sure the layout doesn't break.*