### PR TITLE
Add Arexium (ARX) token.

### DIFF
--- a/config/main.json
+++ b/config/main.json
@@ -223,7 +223,8 @@
     { "addr": "0x226bb599a12c826476e3a771454697ea52e9e220", "name": "PRO", "decimals": 8 },
     { "addr": "0x51ee82641ac238bde34b9859f98f5f311d6e4954", "name": "IQT", "decimals": 8 },
     { "addr": "0x0371a82e4a9d0a4312f3ee2ac9c6958512891372", "name": "STU", "decimals": 18 },
-    { "addr": "0x2f4baef93489b09b5e4b923795361a65a26f55e5", "name": "XHY", "decimals": 8 }
+    { "addr": "0x2f4baef93489b09b5e4b923795361a65a26f55e5", "name": "XHY", "decimals": 8 },
+    { "addr": "0xe256bb0b2a3457e54db3a41cf5a8b826aca222a8", "name": "ARX", "decimals": 18 }
   ],
   "defaultPair": { "token": "MTH", "base": "ETH" },
   "pairs": [
@@ -414,6 +415,7 @@
     { "token": "PRO", "base": "ETH" },
     { "token": "IQT", "base": "ETH" },
     { "token": "STU", "base": "ETH" },
-    { "token": "XHY", "base": "ETH" }
+    { "token": "XHY", "base": "ETH" },
+    { "token": "ARX", "base": "ETH" }
   ]
 }


### PR DESCRIPTION
I would like to add Arexium to etherdelta.

Address: 0xe256bb0b2a3457e54db3a41cf5a8b826aca222a8
Token symbol: ARX
Decimals: 18

Website: https://www.arexium.io/
Twitter: https://twitter.com/arexium_io
Contract Source: https://etherscan.io/address/0xe256bb0b2a3457e54db3a41cf5a8b826aca222a8#code

Verification: https://www.arexium.io/v/

