### PR TITLE
Add Synapse Token (SYN)

### DIFF
--- a/config/main.json
+++ b/config/main.json
@@ -270,7 +270,8 @@
     { "addr": "0xab95e915c123fded5bdfb6325e35ef5515f1ea69", "name": "XNN", "decimals": 18 },
     { "addr": "0x23cb17d7d079518dbff4febb6efcc0de58d8c984", "name": "TRV", "decimals": 16 },
     { "addr": "0x65292eeadf1426cd2df1c4793a3d7519f253913b", "name": "COSS", "decimals": 18 },
-    { "addr": "0x27dce1ec4d3f72c3e457cc50354f1f975ddef488", "name": "AIR", "decimals": 8 }
+    { "addr": "0x27dce1ec4d3f72c3e457cc50354f1f975ddef488", "name": "AIR", "decimals": 8 },
+    { "addr": "0x10B123FdDde003243199aaD03522065dC05827A0", "name": "SYN", "decimals": 18 }
   ],
   "defaultPair": { "token": "KNC", "base": "ETH" },
   "pairs": [
@@ -508,5 +509,6 @@
     { "token": "TRV", "base": "ETH" },
     { "token": "COSS", "base": "ETH" },
     { "token": "AIR", "base": "ETH" }
+    { "token": "SYN", "base": "ETH" }
   ]
 }


### PR DESCRIPTION
Please add Synapse (SYN) Token. Thank you. 

a. Token address: 0x10b123fddde003243199aad03522065dc05827a0
b. Official Web site : https://synapse.ai/
c. Paragraph description of the token:

SYN Token is used for the Synapse Network for decentralized data + machine learning models. SYN Token is an ERC20 standard token developed on top of the Ethereum network.

The SYN token is used to both reward people for access to their data,  support network infrastructure and fees, and reward people for committing to storage and compute through secondary exchange functions. 

Data and models can be bought and sold through the marketplace via fulfillment contracts (oracles, ad-hoc queries), and provenance and access control is kept on chain.

Synapse AI Inc. is our legal entity, and our pre-sale is happening now, with our ICO happening in 4 days on September 30th. 
