### PR TITLE
Add SHIT token

### DIFF
--- a/config/main.json
+++ b/config/main.json
@@ -275,7 +275,8 @@
     { "addr": "0x728781e75735dc0962df3a51d7ef47e798a7107e", "name": "WOLK", "decimals": 18 },
     { "addr": "0xcb97e65f07da24d46bcdd078ebebd7c6e6e3d750", "name": "BTM", "decimals": 8 },
     { "addr": "0x6d5cac36c1ae39f41d52393b7a425d0a610ad9f2", "name": "LLT", "decimals": 8 },
-    { "addr": "0x4156d3342d5c385a87d264f90653733592000581", "name": "SALT", "decimals": 8 }
+    { "addr": "0x4156d3342d5c385a87d264f90653733592000581", "name": "SALT", "decimals": 8 },
+    { "addr": "0xEF2E9966eb61BB494E5375d5Df8d67B7dB8A780D", "name": "SHIT", "decimals": 0 }
   ],
   "defaultPair": { "token": "KNC", "base": "ETH" },
   "pairs": [
@@ -517,6 +518,7 @@
     { "token": "WOLK", "base": "ETH" },
     { "token": "BTM", "base": "ETH" },
     { "token": "LLT", "base": "ETH" },
-    { "token": "SALT", "base": "ETH" }
+    { "token": "SALT", "base": "ETH" },
+    { "token": "SHIT", "base": "ETH" }
   ]
 }


### PR DESCRIPTION
Please add the one and only Shitcoin. Thanks. 💩

a. Token address: 0xEF2E9966eb61BB494E5375d5Df8d67B7dB8A780D
b. Official Web site : https://www.shitcoin.io/
c. Paragraph description of the token: Shitcoin is a revolutionary new crypto token. Read the brown paper at: https://docs.wixstatic.com/ugd/c26de8_82d48cf05a224955a7b1ab5c92323fed.pdf