### PR TITLE
fix(import account): disable browser auto-complete in the import form

### DIFF
--- a/index_com.html
+++ b/index_com.html
@@ -175,7 +175,7 @@
             <h4 class="modal-title trn">import_account</h4>
           </div>
           <div class="modal-body">
-            <form>
+            <form autocomplete="off">
               <div class="form-group">
                 <label for="accountAddr" class="trn">address</label>
                 <input type="text" class="form-control" id="accountAddr" placeholder="0x..." />


### PR DESCRIPTION
__What is in the PR__

This will prevent the browser from storing address and private key,
and make them available for auto-complete.

__Why__
It was surprising for me that my browser would store my credentials when I had to import my account again. It felt quite unsecure. 