### PR TITLE
URGENT: Delist FUDD as it's a scam token

### DIFF
--- a/config/main.json
+++ b/config/main.json
@@ -394,7 +394,6 @@
     { "addr": "0x9397554c07f687b7a20d13c73350cc283765d509", "name": "SHLD", "decimals": 18 },
     { "addr": "0x539efe69bcdd21a83efd9122571a64cc25e0282b", "name": "BLUE", "decimals": 8 },
     { "addr": "0x9af4f26941677c706cfecf6d3379ff01bb85d5ab", "name": "DRT", "decimals": 8 },
-    { "addr": "0xde39e5e5a1b0eeb3afe717d6d011cae88d19451e", "name": "FUDD", "decimals": 8 },
     { "addr": "0xfcb48fdcc479b38068c06ee94249b1516adf09cb", "name": "EURB", "decimals": 5 },
     { "addr": "0x7a79abd3905ef37b8d243c4c28cee73a751eb076", "name": "CM", "decimals": 18 },
     { "addr": "0xebc86d834756621444a8a26b4cf81b625fe310cd", "name": "ETHP", "decimals": 18 },


### PR DESCRIPTION
Please urgently accept the change and delist the token from the exchange. 

Proofs:
https://bitcointalk.org/index.php?topic=2722276.0

CoinMarketCap already delisted it.

thanks,