### PR TITLE
Add MeeTip Token

### DIFF
--- a/config/main.json
+++ b/config/main.json
@@ -713,7 +713,8 @@
     { "addr": "0xfdbc1adc26f0f8f8606a5d63b7d3a3cd21c22b23", "name": "1WO", "decimals": 8 },
     { "addr": "0x27f610bf36eca0939093343ac28b1534a721dbb4", "name": "WAND", "decimals": 18 },
     { "addr": "0xe0c21b3f45fea3e5fdc811021fb1f8842caccad2", "name": "BITC", "decimals": 0 },
-    { "addr": "0xce53a179047ebed80261689367c093c90a94cc08", "name": "EDT", "decimals": 8 }
+    { "addr": "0xce53a179047ebed80261689367c093c90a94cc08", "name": "EDT", "decimals": 8 },
+    { "addr": "0x57a3dc224dccc0526954ff60ca6badd19c274d88", "name": "MTIP", "decimals": 18 }
   ],
   "defaultPair": { "token": "PPT", "base": "ETH" }
 }


### PR DESCRIPTION
Hi dev,

We would like to add our MeeTip token to the tokens menu available on EtherDelta. We raised more than 3M during our ICO.

Token Address: 0x57a3dc224dccc0526954ff60ca6badd19c274d88
Token Name: MeeTip
Token Symbol: MTIP
Decimals: 18
Total Token Supply:  3,318,402.86286166

Website: https://www.meetip.io/
Contract Source: https://etherscan.io/address/0x1CCE4079a9c65920390Ea38d5ffBeeb3F4aAaB77#code