### PR TITLE
Update COSS token address

### DIFF
--- a/config/main.json
+++ b/config/main.json
@@ -270,7 +270,7 @@
     { "addr": "0xf333b2ace992ac2bbd8798bf57bc65a06184afba", "name": "SND", "decimals": 0 },
     { "addr": "0xab95e915c123fded5bdfb6325e35ef5515f1ea69", "name": "XNN", "decimals": 18 },
     { "addr": "0x23cb17d7d079518dbff4febb6efcc0de58d8c984", "name": "TRV", "decimals": 16 },
-    { "addr": "0x65292eeadf1426cd2df1c4793a3d7519f253913b", "name": "COSS", "decimals": 18 },
+    { "addr": "0x9e96604445ec19ffed9a5e8dd7b50a29c899a10c", "name": "COSS", "decimals": 18 },
     { "addr": "0x27dce1ec4d3f72c3e457cc50354f1f975ddef488", "name": "AIR", "decimals": 8 },
     { "addr": "0x10b123fddde003243199aad03522065dc05827a0", "name": "SYN", "decimals": 18 },
     { "addr": "0xcb97e65f07da24d46bcdd078ebebd7c6e6e3d750", "name": "BTM", "decimals": 8 },


### PR DESCRIPTION
The COSS token forked on 04.03.2018 to the ERC223 standard. You can find more at the official announcement on:

https://coss.io/coss-token-update