### PR TITLE
Added HoloToken (HOT)

### DIFF
--- a/config/main.json
+++ b/config/main.json
@@ -713,7 +713,8 @@
     { "addr": "0xfdbc1adc26f0f8f8606a5d63b7d3a3cd21c22b23", "name": "1WO", "decimals": 8 },
     { "addr": "0x27f610bf36eca0939093343ac28b1534a721dbb4", "name": "WAND", "decimals": 18 },
     { "addr": "0xe0c21b3f45fea3e5fdc811021fb1f8842caccad2", "name": "BITC", "decimals": 0 },
-    { "addr": "0xce53a179047ebed80261689367c093c90a94cc08", "name": "EDT", "decimals": 8 }
+    { "addr": "0xce53a179047ebed80261689367c093c90a94cc08", "name": "EDT", "decimals": 8 },
+    { "addr": "0x6c6EE5e31d828De241282B9606C8e98Ea48526E2", "name": "HOT", "decimals": 18 }
   ],
   "defaultPair": { "token": "PPT", "base": "ETH" }
 }


### PR DESCRIPTION
Holo's (https://holo.host) intermediate HoloToken that will be redeemable for Holo fuel.

Source is available at https://github.com/holo-host/ico and https://etherscan.io/address/0x6c6ee5e31d828de241282b9606c8e98ea48526e2#code. Contextual information at https://holo.freshdesk.com/support/solutions/articles/36000003263-about-holotokens.

Also registered as token.holo-host.eth.