### PR TITLE
Fix Holochain (HOT) token guide

### DIFF
--- a/site/tokenGuides/HOT.ejs
+++ b/site/tokenGuides/HOT.ejs
@@ -1,6 +1,5 @@
 
 <blockquote>
-  <p>Hydro Protocol (HOT): A network transport layer protocol for hybrid decentralized exchanges.</p>
-  <footer><a href="https://thehydrofoundation.com/" target="_blank">https://thehydrofoundation.com/</a></footer>
+  <p>Holochain (HOT): Holographic storage for distributed applications.</p>
+  <footer><a href="https://holochain.org/" target="_blank">https://holochain.org/</a></footer>
 </blockquote>
-  


### PR DESCRIPTION
This PR fixes the mislabeled token guide for Holochain (HOT)- it was referencing the hydro protocol.

The contract address for HOLOTOKEN is https://etherscan.io/token/0x6c6ee5e31d828de241282b9606c8e98ea48526e2 which is the same as the listed HOT on EtherDelta. HYDRO PROTOCOL has a contract address of https://etherscan.io/token/0x9af839687f6c94542ac5ece2e317daae355493a1 and can only be reached by using the contract address method.